### PR TITLE
fix: API

### DIFF
--- a/src/revenues/revenues.module.ts
+++ b/src/revenues/revenues.module.ts
@@ -7,7 +7,6 @@ import { User } from 'src/user/entity/user.entity';
 import { AuthModule } from 'src/auth/auth.module';
 import { UserModule } from 'src/user/user.module';
 
-//TODO: when delete revenues, the value of her needs to be summed or diminished in user balance
 @Module({
   imports: [TypeOrmModule.forFeature([Revenue, User]), AuthModule, UserModule],
   providers: [RevenuesService],


### PR DESCRIPTION
In this commit some problems are resolved: 
1. Now the create has validation, the user balance must be greater or equal than zero when a revenue is created;
2. The update also have validation, when a in operation is updated, the old value of the revenue are subtracted to the balance and then add the new value. The reverse thing occurs in out cases. 
3. The delete only is possible if the deleted revenue not corrupt the flux of revenues. For e.g: if the user have a "in" revenue, with the value of 1000, and after that create two out revenues, with the values 200 and 110. Few steps later, the user decide to update the first in revenue, putting the value equal 300, but he can't do this, cause him balance will be negative. Cause this, to switch this flux, all the revenues needs to be deleted.

## Steps to do:
- Put more security, adding the secrets, database configs and others in the .env;
- Start to develop the tests using jest